### PR TITLE
[Feat]: add delete message and mute conversation mcp tools

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -654,6 +654,7 @@ def _ensure_download_directory(download_path: str) -> None:
     """Ensure download directory exists."""
     Path(download_path).mkdir(parents=True, exist_ok=True)
 
+
 def _download_single_media(media, download_path: str) -> str:
     """Download a single media item and return the file path."""
     media_type = media.media_type
@@ -664,10 +665,12 @@ def _download_single_media(media, download_path: str) -> str:
     else:
         raise ValueError(f"Unsupported media type: {media_type}")
 
+
 def _find_message_in_thread(thread_id: str, message_id: str):
     """Find a specific message in a thread."""
     messages = client.direct_messages(thread_id, 100)
     return next((m for m in messages if str(m.id) == message_id), None)
+
 
 @mcp.tool()
 def list_media_messages(thread_id: str, limit: int = 100) -> Dict[str, Any]:
@@ -740,6 +743,7 @@ def download_media_from_message(message_id: str, thread_id: str, download_path: 
             "message": f"Failed to download media: {str(e)}"
         }
 
+
 @mcp.tool()
 def download_shared_post_from_message(message_id: str, thread_id: str, download_path: str = "./downloads") -> Dict[str, Any]:
     """Download media from a shared post/reel/clip in a DM message and get the local file path.
@@ -800,6 +804,58 @@ def download_shared_post_from_message(message_id: str, thread_id: str, download_
             return {"success": False, "message": f"Failed to download shared post/reel/clip: {str(e)}"}
     except Exception as e:
         return {"success": False, "message": f"Failed to process message: {str(e)}"}
+
+
+@mcp.tool()
+def delete_message(thread_id: str, message_id: str) -> Dict[str, Any]:
+    """Delete a message from a direct message thread.
+
+    Args:
+        thread_id: The thread ID containing the message.
+        message_id: The ID of the message to delete.
+    Returns:
+        A dictionary with success status and a status message.
+    """
+    if not thread_id or not message_id:
+        return {"success": False, "message": "Both thread_id and message_id must be provided."}
+    
+    try:
+        result = client.direct_message_delete(int(thread_id), int(message_id))
+        if result:
+            return {"success": True, "message": "Message deleted successfully."}
+        else:
+            return {"success": False, "message": "Failed to delete message."}
+    except Exception as e:
+        return {"success": False, "message": str(e)}
+
+
+@mcp.tool()
+def mute_conversation(thread_id: str, mute: bool = True) -> Dict[str, Any]:
+    """Mute or unmute a direct message conversation.
+
+    Args:
+        thread_id: The thread ID to mute/unmute.
+        mute: True to mute, False to unmute the conversation.
+    Returns:
+        A dictionary with success status and a status message.
+    """
+    if not thread_id:
+        return {"success": False, "message": "Thread ID must be provided."}
+    
+    try:
+        if mute:
+            result = client.direct_thread_mute(int(thread_id))
+            action = "muted"
+        else:
+            result = client.direct_thread_unmute(int(thread_id))
+            action = "unmuted"
+        
+        if result:
+            return {"success": True, "message": f"Conversation {action} successfully."}
+        else:
+            return {"success": False, "message": f"Failed to {action.rstrip('d')} conversation."}
+    except Exception as e:
+        return {"success": False, "message": str(e)}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces several changes to the `src/mcp_server.py` file, focusing on improving functionality for managing Instagram direct messages. The updates include the addition of new tools for deleting messages and muting/unmuting conversations, as well as minor formatting adjustments for cleaner code.

### New functionality:

* Added a `delete_message` function to allow deletion of a specific message from a direct message thread. This function validates input, performs the deletion using the `client.direct_message_delete` method, and returns a success or failure response.
* Added a `mute_conversation` function to enable muting or unmuting of a direct message thread. The function uses `client.direct_thread_mute` and `client.direct_thread_unmute` methods and provides feedback on the operation's success.

### Code formatting:

* Added blank lines between functions for improved readability. [[1]](diffhunk://#diff-634efeeba47818169be0eccc0867a64a8935da7d8bb8b83079acc4e3dd3f993eR657) [[2]](diffhunk://#diff-634efeeba47818169be0eccc0867a64a8935da7d8bb8b83079acc4e3dd3f993eR668-R674) [[3]](diffhunk://#diff-634efeeba47818169be0eccc0867a64a8935da7d8bb8b83079acc4e3dd3f993eR746)