### PR TITLE
Feat: Added support for sticky sessions so login wont hang

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,6 +214,8 @@ Below is a list of all available tools and what they do:
 
 ## Troubleshooting
 
+**Instagram Login Hanging:** The server now includes automatic session management to prevent login hangs. Session files (e.g., `username_session.json`) are automatically created and reused to maintain authentication state between runs.
+
 For additional Claude Desktop integration troubleshooting, see the [MCP documentation](https://modelcontextprotocol.io/quickstart/server#claude-for-desktop-integration-issues). The documentation includes helpful tips for checking logs and resolving common issues.
 
 ---

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -822,7 +822,22 @@ if __name__ == "__main__":
 
    try:
        logger.info("Attempting to login to Instagram...")
+       
+       # CRITICAL FIX: Session file handling for persistent authentication
+       # Without this, Instagram login hangs due to rate limiting and security measures
+       # Session files allow Instagram to recognize the client and avoid fresh authentication
+       # This prevents the MCP server from hanging after "🚀 Attempting to send DM"
+       SESSION_FILE = Path(f"{username}_session.json")
+       if SESSION_FILE.exists():
+           logger.info(f"Loading existing session from {SESSION_FILE}")
+           client.load_settings(SESSION_FILE)
+       
        client.login(username, password)
+       
+       # Save session for future use to avoid repeated fresh authentication
+       client.dump_settings(SESSION_FILE)
+       logger.info(f"Session saved to {SESSION_FILE}")
+       
        logger.info("Successfully logged in to Instagram")
        mcp.run(transport="stdio")
    except Exception as e:


### PR DESCRIPTION
Updated code to be able to handle the sticky sessions and avoid hangs on the ready to send DM stage and generate an MFA code. Expectation is that in the user's environment they are and should be already validated.