### PR TITLE
refactor: stores sessions in a .sessions folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pyvenv.cfg
 *.db
 .env
 .venv
+.sessions/

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -883,7 +883,9 @@ if __name__ == "__main__":
        # Without this, Instagram login hangs due to rate limiting and security measures
        # Session files allow Instagram to recognize the client and avoid fresh authentication
        # This prevents the MCP server from hanging after "🚀 Attempting to send DM"
-       SESSION_FILE = Path(f"{username}_session.json")
+       SESSION_DIR = Path(__file__).parent / ".sessions"
+       SESSION_DIR.mkdir(exist_ok=True)
+       SESSION_FILE = SESSION_DIR / f"{username}_session.json"
        if SESSION_FILE.exists():
            logger.info(f"Loading existing session from {SESSION_FILE}")
            client.load_settings(SESSION_FILE)


### PR DESCRIPTION
This PR updates the session file path logic to store `instagrapi` session files inside a dedicated `.sessions/` directory, instead of the runtime project folder.

This keeps the src directory clean and is easy to `.gitignore`. It also ensures that sessions are stored in a deterministic location instead of the runtime directory.